### PR TITLE
Fix numpy version that networkx==2.4 expects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 networkx==2.4
+numpy==1.20.1
 rhasspy-asr~=0.2.0
 rhasspy-nlu~=0.3.0


### PR DESCRIPTION
See https://github.com/rhasspy/rhasspy-remote-http-hermes/pull/5 for details